### PR TITLE
Improved git-ls to produce nicer colours

### DIFF
--- a/git-ls
+++ b/git-ls
@@ -45,8 +45,6 @@ Cred='\033[0;31m'
 Cgrey='\033[0;37m'
 Creset='\033[0m'
 
-file_length="$(ls -A | wc -l)"
-
 if [ "$dotfiles" -eq 1 ]
 then
     shopt -s dotglob
@@ -59,7 +57,7 @@ do
         continue
     fi
 
-    printf "%-${file_length}s\t" "$file"
+    printf "%-20s\t" "$file"
 
     status="$(git status --porcelain "$file")"
 
@@ -73,7 +71,7 @@ do
     then
         echo -en "${Cgrey}Gitignored$Creset"
     else
-        git log -1 --pretty="format:%ar%n%C(Yellow)%h%Creset %s" "$file" | tr "\n" "\t"
+        git log -1 --color=always --pretty=format:'%C(bold green)%<(20)%ar%C(reset)%C(bold blue)%h%C(reset)%n%C(white)%s%C(reset)' "$file" | tr "\n" "\t"
     fi
 
     echo ""

--- a/test/git_ls_test.py
+++ b/test/git_ls_test.py
@@ -10,9 +10,9 @@ class GitLsTest(unittest.TestCase):
         repo.make_commit('2')
         actual = PROGRAM.git.ls()
         expected = [
-            '0   \t.* ago\tc0d1dbb 0',
-            '1   \t.* ago\ta03c0f8 1',
-            '2   \t.* ago\t043df1f 2',
+            r'0.* ago.*c0d1dbb.*0.*',
+            r'1.* ago.*a03c0f8.*1.*',
+            r'2.* ago.*043df1f.*2.*',
         ]
         for a, e in zip(actual, expected):
             self.assertRegex(a, e)


### PR DESCRIPTION
Used a static padding instead of [using the number of files as padding](https://github.com/rec/gitz/blob/9a1e06040401d3359938e30cfe41ba7af630bbdf/git-ls#L48).

Colours now appear for both commits and time since committed.

![Improved git-ls](https://user-images.githubusercontent.com/23520617/62789355-52c96a00-bafb-11e9-96c4-470ee3f2a792.png)
